### PR TITLE
Change dbtToolCM to dbtToolLineage

### DIFF
--- a/dtbtool/Android.mk
+++ b/dtbtool/Android.mk
@@ -10,7 +10,7 @@ LOCAL_CFLAGS += \
 	-Wall
 
 ## Hybrid v1/v2 dtbTool. Use a different name to avoid conflicts with copies in device repos
-LOCAL_MODULE := dtbToolCM
+LOCAL_MODULE := dtbToolLineage
 LOCAL_MODULE_TAGS := optional
 
 include $(BUILD_HOST_EXECUTABLE)


### PR DESCRIPTION
Fix Error:

[ 99% 1115/1116] glob vendor/qcom/opensource/interfaces/*/Android.bp
ninja: error: '/home/alaskalinuxuser/compile/in_progress/lin15_squirel/out/host/linux-x86/bin/dtbToolLineage', needed by '/home/alaskalinuxuser/compile/in_progress/lin15_squirel/out/target/product/h811/dt.img', missing and no known rule to make it